### PR TITLE
Use deprecated hidden constructors as last option only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ plugins {
     id 'com.github.kt3k.coveralls' version "2.10.1"
     id 'de.fayard.buildSrcVersions' version "0.7.0"
     id "io.codearte.nexus-staging" version '0.22.0'
+    id 'org.jetbrains.kotlin.plugin.serialization' version "1.5.0"
 }
 
 apply plugin: 'io.codearte.nexus-staging'

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -72,4 +72,7 @@ object Libs {
      * https://github.com/npryce/hamkrest
      */
     const val hamkrest: String = "com.natpryce:hamkrest:" + Versions.hamkrest
+
+    const val kotlinx_serialization: String = "org.jetbrains.kotlinx:kotlinx-serialization-json:" + Versions.kotlinx_serialization
+
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -26,6 +26,8 @@ object Versions {
 
     const val hamkrest: String = "1.8.0.1"
 
+    const val kotlinx_serialization: String = "1.2.2"
+
     /**
      * Current version: "6.5.1"
      * See issue 19: How to update Gradle itself?

--- a/fabrikate4k/build.gradle
+++ b/fabrikate4k/build.gradle
@@ -1,8 +1,11 @@
 description = 'ForkHandles test utility to instantiate objects with fake data'
 
+apply plugin: 'kotlinx-serialization'
+
 dependencies {
     api Libs.kotlin_stdlib_jdk8
     api Libs.kotlin_reflect
     testApi Config.TestDependencies
     testApi Libs.kotlin_test
+    testApi Libs.kotlinx_serialization
 }

--- a/fabrikate4k/src/test/kotlin/dev/forkhandles/fabrikate/InstanceFabricatorTest.kt
+++ b/fabrikate4k/src/test/kotlin/dev/forkhandles/fabrikate/InstanceFabricatorTest.kt
@@ -4,6 +4,7 @@ import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.present
 import dev.forkhandles.fabrikate.InstanceFabricator.NoUsableConstructor
+import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -371,5 +372,15 @@ class InstanceFabricatorTest {
     @Test
     fun `does enums`() {
         assertThat(Fabrikate(FabricatorConfig(2).withStandardMappings()).random<T>().toString(), equalTo("T(a=D, b=[D, A, A, D, A])"))
+    }
+
+    @Serializable
+    data class KotlinSerializable(val string: String)
+
+    @Test
+    fun `does not create nulls on non-nullables for serializable classes`(){
+        val random = Fabrikate(FabricatorConfig(84).withStandardMappings()).random<KotlinSerializable>()
+        val nonNullableString = random.string
+        assertThat(nonNullableString, present())
     }
 }


### PR DESCRIPTION
Kotlinx-serialization uses apparently hidden deprecated constructors for instantiating objects.
This PR filters deprecated  hidden constructors and uses them when there is no other constructor only.