### PR TITLE
Allow registered Fabricators to override defaults

### DIFF
--- a/fabrikate4k/src/main/kotlin/dev/forkhandles/fabrikate/InstanceFabricator.kt
+++ b/fabrikate4k/src/main/kotlin/dev/forkhandles/fabrikate/InstanceFabricator.kt
@@ -81,12 +81,13 @@ class InstanceFabricator(private val config: FabricatorConfig) {
 
     private fun makeStandardInstanceOrNull(classRef: KClass<*>, type: KType) = with(config) {
         when {
+            mappings.containsKey(classRef) -> mappings[classRef]!!.invoke()
             classRef == Set::class -> makeRandomSet(classRef, type)
             classRef == List::class -> makeRandomList(classRef, type)
             classRef == Collection::class -> makeRandomList(classRef, type)
             classRef == Map::class -> makeRandomMap(classRef, type)
             classRef.isSubclassOf(Enum::class) -> makeRandomEnum(classRef)
-            else -> mappings[classRef]?.invoke()
+            else -> null
         }
     }
 

--- a/fabrikate4k/src/test/kotlin/dev/forkhandles/fabrikate/InstanceFabricatorTest.kt
+++ b/fabrikate4k/src/test/kotlin/dev/forkhandles/fabrikate/InstanceFabricatorTest.kt
@@ -6,6 +6,7 @@ import com.natpryce.hamkrest.present
 import dev.forkhandles.fabrikate.InstanceFabricator.NoUsableConstructor
 import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -382,5 +383,27 @@ class InstanceFabricatorTest {
         val random = Fabrikate(FabricatorConfig(84).withStandardMappings()).random<KotlinSerializable>()
         val nonNullableString = random.string
         assertThat(nonNullableString, present())
+    }
+
+    class TestListFabricator: Fabricator<List<String>>{
+        override fun invoke(): List<String> {
+            return testList
+        }
+
+        companion object {
+            val testList = listOf("TestList")
+        }
+    }
+
+    @Test
+    fun `registered Fabricators override defaults`(){
+        val defaultFabrikate = Fabrikate(FabricatorConfig())
+        val overriddenFabrikate = Fabrikate(FabricatorConfig().register(TestListFabricator()))
+
+        val randomDefault = defaultFabrikate.random<List<String>>()
+        val randomOverridden = overriddenFabrikate.random<List<String>>()
+
+        assertNotEquals(randomDefault, randomOverridden)
+        assertThat(randomOverridden, equalTo(TestListFabricator.testList))
     }
 }


### PR DESCRIPTION
Changing the order of when branches to give priority to registered Fabricators over default behaviour