### PR TITLE
minor fixes

### DIFF
--- a/time4k/src/main/kotlin/dev/forkhandles/time/DeterministicScheduler.kt
+++ b/time4k/src/main/kotlin/dev/forkhandles/time/DeterministicScheduler.kt
@@ -1,5 +1,6 @@
 package dev.forkhandles.time
 
+import java.lang.IllegalArgumentException
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.Callable
@@ -270,6 +271,12 @@ class DeterministicScheduler(startTime: Instant = Instant.now()) : ScheduledExec
 
         if ( isShutdown ) {
             return
+        }
+
+        if ( newTask.repeatDelay != null ) {
+            if (newTask.repeatDelay.isNegative || newTask.repeatDelay.isZero) {
+                throw IllegalArgumentException("repeat ${newTask.repeatDelay} is zero or negative ")
+            }
         }
 
         while (next != null && next.delay <= newTask.delay) {

--- a/time4k/src/test/kotlin/dev/forkhandles/time/DeterministicSchedulerTests.kt
+++ b/time4k/src/test/kotlin/dev/forkhandles/time/DeterministicSchedulerTests.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
+import java.lang.IllegalArgumentException
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.Callable
@@ -308,6 +309,14 @@ class DeterministicSchedulerTests {
         future.get()
     }
 
+    @Test
+    fun rejectScheduleIfOutOfBounds() {
+        val task = trackedRunnable("thing")
+        assertThrows(IllegalArgumentException::class.java) { scheduler.scheduleWithFixedDelay(task, 1, -1, MILLISECONDS) }
+        assertThrows(IllegalArgumentException::class.java) { scheduler.scheduleWithFixedDelay(task, 1, 0, MILLISECONDS) }
+        assertThrows(IllegalArgumentException::class.java) { scheduler.scheduleAtFixedRate(task, 1, -1, MILLISECONDS) }
+        assertThrows(IllegalArgumentException::class.java) { scheduler.scheduleAtFixedRate(task, 1, 0, MILLISECONDS) }
+    }
 
     @Test
     fun isNotShutdownUntilItIs() {

--- a/time4k/src/test/kotlin/dev/forkhandles/time/DeterministicSchedulerTests.kt
+++ b/time4k/src/test/kotlin/dev/forkhandles/time/DeterministicSchedulerTests.kt
@@ -8,14 +8,17 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
+import java.time.Duration
 import java.time.Instant
-import java.util.ArrayList
-import java.util.Arrays
 import java.util.concurrent.Callable
+import java.util.concurrent.CancellationException
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.TimeUnit.SECONDS
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 
 class DeterministicSchedulerTests {
     private val scheduler = DeterministicScheduler()
@@ -61,7 +64,7 @@ class DeterministicSchedulerTests {
 
         scheduler.runUntilIdle()
 
-        assertEquals(Arrays.asList(commandA), invoked)
+        assertEquals(listOf(commandA), invoked)
         assertTrue(future.isDone, "future should be done after running the task")
         assertNull(future.get(), "result of future should be null")
     }
@@ -168,8 +171,10 @@ class DeterministicSchedulerTests {
 
     @Test
     fun tickingTimeForwardRunsCommandsExecutedByScheduledCommands() {
-        scheduler.schedule({ scheduler.execute { scheduler.execute(commandC) } },
-            1, MILLISECONDS)
+        scheduler.schedule(
+            { scheduler.execute { scheduler.execute(commandC) } },
+            1, MILLISECONDS
+        )
 
         scheduler.schedule(commandD, 2, MILLISECONDS)
 
@@ -257,7 +262,8 @@ class DeterministicSchedulerTests {
     @Test
     fun testCanScheduleCallablesAndGetTheirResultAfterTheyHaveBeenExecuted() {
         val future = scheduler.schedule(
-            trackedCallable("A"), 1, SECONDS)
+            trackedCallable("A"), 1, SECONDS
+        )
         assertFalse(future.isDone, "is not done")
         scheduler.tick(1, SECONDS)
         assertTrue(future.isDone, "is done")
@@ -273,6 +279,105 @@ class DeterministicSchedulerTests {
         assertThrows(UnsupportedOperationException::class.java) { future[TIMEOUT_IGNORED.toLong(), SECONDS] }
     }
 
+
+    @Test
+    fun testCancellingAFutureThatIsNotYetExecuted() {
+        val task = trackedCallable("result")
+        val future = scheduler.schedule(task, 1, SECONDS)
+        val wasAbleToCancel = future.cancel(true)
+        assertEquals(true, wasAbleToCancel, "was able to cancel")
+        assertEquals(true, future.isCancelled, "isCancelled")
+        assertEquals(true, future.isDone, "isDone")
+        assertThrows(CancellationException::class.java) { future.get() }
+    }
+
+    @Test
+    fun testCancellingAFutureThatIsAlreadyExecuted() {
+        val task = trackedCallable("result")
+        val future = scheduler.schedule(task, 1, SECONDS)
+        assertEquals(false, future.isDone, "isDone")
+
+        scheduler.tick(Duration.ofSeconds(1))
+
+        assertEquals(true, future.isDone, "isDone")
+
+        val wasAbleToCancel = future.cancel(true)
+
+        assertEquals(false, wasAbleToCancel, "was able to cancel")
+        assertEquals(false, future.isCancelled, "isCancelled")
+        future.get()
+    }
+
+
+    @Test
+    fun isNotShutdownUntilItIs() {
+        assertEquals(false, scheduler.isShutdown)
+        scheduler.shutdown()
+        assertEquals(true, scheduler.isShutdown)
+    }
+
+    @Test
+    fun isNotShutdownUntilItIsNow() {
+        assertEquals(false, scheduler.isShutdown)
+        scheduler.shutdownNow()
+        assertEquals(true, scheduler.isShutdown)
+    }
+
+    @Test
+    fun isTerminatedAsSoonAsItIsShutdown() {
+        assertEquals(false, scheduler.isTerminated)
+        scheduler.shutdown()
+        assertEquals(true, scheduler.isTerminated)
+    }
+
+    @Test
+    fun cannotWaitForTerminationUntilShutdown() {
+        // this is a small bodge to the differences between sync and async operation - but here we assume the same
+        // thread calls shutdown & await termination, like if shutting down a service under test
+        assertThrows(UnsupportedSynchronousOperationException::class.java) { scheduler.awaitTermination(1, SECONDS) }
+    }
+
+    @Test
+    fun waitForTerminationWhenShutdown() {
+        scheduler.shutdown()
+        assertTrue(scheduler.awaitTermination(1, SECONDS))
+    }
+
+    @Test
+    fun tasksSubmittedAfterShutdownAreIgnored() {
+        val counter = AtomicInteger()
+        scheduler.shutdown()
+        scheduler.schedule({ counter.incrementAndGet() }, 1, SECONDS)
+        scheduler.tick(Duration.ofSeconds(2))
+        assertEquals(0, counter.get())
+    }
+
+    @Test
+    fun tasksAreExecutedUntilShutdown() {
+        val counter = AtomicInteger()
+        scheduler.schedule({ counter.incrementAndGet(); scheduler.shutdown() }, 1, SECONDS)
+        scheduler.tick(Duration.ofSeconds(2))
+        assertEquals(1, counter.get())
+    }
+
+    @Test
+    fun longTimePeriodsWillInvolveRunningTheServiceMultipleTimes() {
+
+        val counter = AtomicLong(0)
+
+        scheduler.scheduleAtFixedRate({ counter.incrementAndGet() }, 1, 5, TimeUnit.MINUTES)
+        scheduler.tick(Duration.ofHours(1))
+
+        assertEquals(12, counter.get())
+    }
+
+    @Test
+    fun periodicTaskThrowingExceptionSuppressesSubsequentExecutions() {
+        val counter = AtomicLong(0)
+        scheduler.scheduleAtFixedRate({ counter.incrementAndGet(); throw NullPointerException() }, 0, 1, SECONDS)
+        scheduler.tick(Duration.ofSeconds(3))
+        assertEquals(1, counter.get())
+    }
 
     private fun trackedRunnable(name: String): Runnable {
         return object : Runnable {


### PR DESCRIPTION
- tasks that throw should not be rescheduled
- cancelled tasks should be "done"
- completed tasks cannot be cancelled
- service can be shutdown

shutdown doesn't make sense for all use cases, but it does make sense when you have a "main" with a scheduler that is being controlled by a test, and the test instructs the "main" to shutdown, which in turn calls scheduler shutdown - which can now complete without error.

The other changes are where the tasks don't conform to the API spec.

see: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Future.html
 This attempt will fail if the task has already completed, has already been cancelled, or could not be cancelled for some other reason. If successful, and this task has not started when cancel is called, this task should never run. 
After this method returns, subsequent calls to isDone() will always return true.

see:  
https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ScheduledExecutorService.html
If any execution of the task encounters an exception, subsequent executions are suppressed 