### PR TITLE
Test registration override using standard mappings

### DIFF
--- a/fabrikate4k/src/test/kotlin/dev/forkhandles/fabrikate/InstanceFabricatorTest.kt
+++ b/fabrikate4k/src/test/kotlin/dev/forkhandles/fabrikate/InstanceFabricatorTest.kt
@@ -418,8 +418,8 @@ class InstanceFabricatorTest {
 
     @Test
     fun `registered Fabricators override defaults`(){
-        val defaultFabrikate = Fabrikate(FabricatorConfig())
-        val overriddenFabrikate = Fabrikate(FabricatorConfig().register(TestListFabricator()))
+        val defaultFabrikate = Fabrikate(FabricatorConfig(2).withStandardMappings())
+        val overriddenFabrikate = Fabrikate(FabricatorConfig().withStandardMappings().register(TestListFabricator()))
 
         val randomDefault = defaultFabrikate.random<List<String>>()
         val randomOverridden = overriddenFabrikate.random<List<String>>()


### PR DESCRIPTION
This is more of a discussion/question PR than an actual issue: Having run into an issue with `register`ing, I checked the tests. The one modified here has (to me) a misleading title, because `defaultFabrikate` does not have any `Fabrikator`s registered, so `overridenFabrikate` does not override anything. (I am not a native speaker, but in my understanding the code looks more like "adding", because nothing is present to override.) I think the proposed changes make the test work in a way the title describes. But since I am not sure, I'd like some feedback on it. (I am also fairly new to the codebase.)