### PR TITLE
add new result4k example, and documentation for kotest and hamkrest

### DIFF
--- a/result4k/core/src/test/kotlin/dev/forkhandles/result4k/WeatherExample.kt
+++ b/result4k/core/src/test/kotlin/dev/forkhandles/result4k/WeatherExample.kt
@@ -1,0 +1,38 @@
+package dev.forkhandles.result4k
+
+import java.math.BigDecimal
+
+data class Weather(val kelvin: BigDecimal, val pascals: Int)
+data class Conditions(val message: String)
+data class WeatherError(val code: Int, val message: String)
+
+private val cold = 283.15.toBigDecimal()
+private val hot = 298.15.toBigDecimal()
+
+fun getWeather(location: Int): Result<Weather, WeatherError> = when(location) {
+    in 1..100 -> Success(Weather(kelvin = BigDecimal("295.15"), pascals = 101_390))
+    else -> Failure(WeatherError(code = 404, message = "unsupported location"))
+}
+
+fun Weather.toConditions(): Result<Conditions, WeatherError> {
+     return when {
+         kelvin < BigDecimal.ZERO -> Failure(WeatherError(400, "impossible!"))
+         kelvin < cold -> Success(Conditions("cold :("))
+         kelvin > hot -> Success(Conditions("HOT! X("))
+         else -> Success(Conditions("Nice :)"))
+     }
+}
+
+/**
+ * Get the current weather, interpret the conditions, and print them
+ */
+fun main() {
+    val forecast: String = getWeather(20) // get initial result (success or failure)
+        .flatMap(Weather::toConditions) // convert success to result (success or failure)
+        .map { it.message } // convert success to success
+        .mapFailure { message -> "WARNING: $message" } // convert failure to failure
+        .peekFailure { println("Physics has imploded!") }  // perform side-effect if failure
+        .get() // unwrap success, or failure if same type as success (in this case, String)
+
+    println(forecast)
+}

--- a/result4k/core/src/test/kotlin/dev/forkhandles/result4k/petStoreExample.kt
+++ b/result4k/core/src/test/kotlin/dev/forkhandles/result4k/petStoreExample.kt
@@ -9,7 +9,7 @@ data class Adoption(val humanId: HumanId, val pet: Pet)
 // define some potential errors (a sealed interface works well too!)
 enum class PetError { PetNotFound, PetNotForAdoption, OwnerBlacklisted }
 
-class AdoptionService(
+class PetStoreExample(
     val pets: Set<Pet>,
     val blacklist: Set<HumanId>,
     val adoptions: MutableSet<Adoption>
@@ -49,7 +49,7 @@ class AdoptionService(
  *
  * If any of the functions fails, the subsequent ones will not execute, and the failure will be returned instead
  */
-fun AdoptionService.adoptByNameAndBrag(humanId: HumanId, name: String): Result<Adoption, PetError> = findPet(name)
+fun PetStoreExample.adoptByNameAndBrag(humanId: HumanId, name: String): Result<Adoption, PetError> = findPet(name)
     .flatMap { pet -> adopt(humanId, pet.id) }
     .peek { adoption -> brag(adoption) } // bragging returns Unit, so we use "peek" to ignore the Success value
 
@@ -61,7 +61,7 @@ fun main() {
     val pet2 = Pet(2, "Freya")
     val pet3 = Pet(3, "Snowball")
 
-    val service = AdoptionService(
+    val service = PetStoreExample(
         pets = setOf(pet1, pet2, pet3),
         blacklist = setOf(human1),
         adoptions = mutableSetOf(Adoption(human2, pet1))

--- a/result4k/hamkrest/build.gradle
+++ b/result4k/hamkrest/build.gradle
@@ -3,4 +3,6 @@ description = 'ForkHandles Library Testing Helpers (Kotest)'
 dependencies {
     implementation(project(":result4k"))
     implementation("com.natpryce:hamkrest:_")
+
+    testImplementation(project(path: ":result4k", configuration: "testArtifacts"))
 }

--- a/result4k/hamkrest/src/test/kotlin/dev/forkhandles/result4k/hamkrest/WeatherExampleHamkrest.kt
+++ b/result4k/hamkrest/src/test/kotlin/dev/forkhandles/result4k/hamkrest/WeatherExampleHamkrest.kt
@@ -1,0 +1,28 @@
+package dev.forkhandles.result4k.hamkrest
+
+import com.natpryce.hamkrest.assertion.assertThat
+import dev.forkhandles.result4k.Weather
+import dev.forkhandles.result4k.WeatherError
+import dev.forkhandles.result4k.getWeather
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class WeatherExampleHamkrest {
+    @Test
+    fun `assert any success`() = assertThat(getWeather(30), isSuccess())
+
+    @Test
+    fun `assert exact success`() = assertThat(
+        getWeather(20),
+        isSuccess(Weather(BigDecimal("295.15"), 101_390))
+    )
+
+    @Test
+    fun `assert any failure`() = assertThat(getWeather(9001), isFailure())
+
+    @Test
+    fun `assert exact failure`() = assertThat(
+        getWeather(9001),
+        isFailure(WeatherError(404, "unsupported location"))
+    )
+}

--- a/result4k/kotest/build.gradle
+++ b/result4k/kotest/build.gradle
@@ -3,4 +3,6 @@ description = 'ForkHandles Library Testing Helpers (Kotest)'
 dependencies {
     implementation(project(":result4k"))
     implementation("io.kotest:kotest-assertions-core-jvm:_")
+
+    testImplementation(project(path: ":result4k", configuration: "testArtifacts"))
 }

--- a/result4k/kotest/src/test/kotlin/dev/forkhandles/result4k/kotest/WeatherExampleKotest.kt
+++ b/result4k/kotest/src/test/kotlin/dev/forkhandles/result4k/kotest/WeatherExampleKotest.kt
@@ -1,0 +1,33 @@
+package dev.forkhandles.result4k.kotest
+
+import dev.forkhandles.result4k.Weather
+import dev.forkhandles.result4k.WeatherError
+import dev.forkhandles.result4k.getWeather
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.ints.shouldBeInRange
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class WeatherExampleKotest {
+    @Test
+    fun `assert any success`() = getWeather(30).shouldBeSuccess()
+
+    @Test
+    fun `assert exact success`() = getWeather(20) shouldBeSuccess Weather(BigDecimal("295.15"), 101_390)
+
+    @Test
+    fun `assert success block`() = getWeather(10) shouldBeSuccess { weather ->
+        weather.pascals shouldBeGreaterThan 100_000
+    }
+
+    @Test
+    fun `assert any failure`() = getWeather(9001).shouldBeFailure()
+
+    @Test
+    fun `assert exact failure`() = getWeather(9001) shouldBeFailure WeatherError(404, "unsupported location")
+
+    @Test
+    fun `assert failure block`() = getWeather(9001) shouldBeFailure { error ->
+        error.code shouldBeInRange 400..499
+    }
+}


### PR DESCRIPTION
The new example ended up being a bit bigger than I would have liked, but I felt like it was crucial to show that you can `flatMap` a result to another `Result` of another type.

This will also highlight the inclusion of the new test modules for result4k; of which I was very happy to discover!