### PR TITLE
[fabrikate4k] feat: provide fabrikate to fabricators

### DIFF
--- a/fabrikate4k/src/main/kotlin/dev/forkhandles/fabrikate/FabricatorConfig.kt
+++ b/fabrikate4k/src/main/kotlin/dev/forkhandles/fabrikate/FabricatorConfig.kt
@@ -4,46 +4,68 @@ import dev.forkhandles.fabrikate.FabricatorConfig.NullableStrategy.RandomlySetTo
 import kotlin.random.Random
 import kotlin.reflect.KClass
 
-class FabricatorConfig(
-    seed: Int = 861_084_310,
+data class FabricatorConfig(
+    val random: Random = Random(861_084_310),
     val collectionSizes: IntRange = 1..5,
-    val nullableStrategy: NullableStrategy = RandomlySetToNull
+    val nullableStrategy: NullableStrategy = RandomlySetToNull,
+    val mappings: Map<KClass<*>, Fabricator<*>> = emptyMap(),
 ) {
+    companion object {
+        operator fun invoke(
+            seed: Int = 861_084_310,
+            collectionSizes: IntRange = 1..5,
+            nullableStrategy: NullableStrategy = RandomlySetToNull,
+            mappings: Map<KClass<*>, Fabricator<*>> = emptyMap(),
+        ): FabricatorConfig = FabricatorConfig(Random(seed), collectionSizes, nullableStrategy, mappings)
+    }
+
     enum class NullableStrategy { RandomlySetToNull, NeverSetToNull, AlwaysSetToNull }
 
-    val random: Random = Random(seed)
-    val mappings = mutableMapOf<KClass<*>, Fabricator<*>>()
-
-    fun withStandardMappings() = apply {
-        register(StringFabricator(random = random))
-        register(LongFabricator(random))
-        register(BooleanFabricator(random))
-        register(ByteFabricator(random))
-        register(IntFabricator(random))
-        register(DoubleFabricator(random))
-        register(FloatFabricator(random))
-        register(CharFabricator(random = random))
-        register(BytesFabricator(random = random))
-        register(BigIntegerFabricator(random = random))
-        register(BigDecimalFabricator(random = random))
-        register(InstantFabricator(random))
-        register(LocalDateFabricator(random))
-        register(LocalTimeFabricator(random))
-        register(LocalDateTimeFabricator(random))
-        register(YearMonthFabricator(random))
-        register(OffsetDateTimeFabricator(random))
-        register(OffsetTimeFabricator(random))
-        register(ZonedDateTimeFabricator(random))
-        register(DurationFabricator(random))
-        register(DateFabricator(random))
-        register(UriFabricator(random))
-        register(UrlFabricator(random))
-        register(FileFabricator())
-        register(UUIDFabricator(random))
-        register(AnyFabricator())
+    fun withStandardMappings(): FabricatorConfig = withMappings {
+        registerStandardMappings()
     }
 
-    inline fun <reified T : Any> register(noinline fabricator: Fabricator<T>) = apply {
-        mappings[T::class] = fabricator
+    fun withMappings(fn: MutableMap<KClass<*>, Fabricator<*>>.() -> Unit): FabricatorConfig = copy(
+        mappings = mappings.toMutableMap().apply(fn),
+    )
+
+    inline fun <reified T : Any> withMapping(fabricator: Fabricator<T>): FabricatorConfig = withMappings {
+        register(fabricator)
     }
+
+    inline fun <reified T : Any> register(fabricator: Fabricator<T>): FabricatorConfig =
+        withMapping(fabricator)
+}
+
+inline fun <reified T> MutableMap<KClass<*>, Fabricator<*>>.register(fabricator: Fabricator<T>) {
+    this[T::class] = fabricator
+}
+
+fun MutableMap<KClass<*>, Fabricator<*>>.registerStandardMappings() {
+    register(StringFabricator())
+    register(LongFabricator())
+    register(BooleanFabricator())
+    register(ByteFabricator())
+    register(IntFabricator())
+    register(DoubleFabricator())
+    register(FloatFabricator())
+    register(CharFabricator())
+    register(BytesFabricator())
+    register(BigIntegerFabricator())
+    register(BigDecimalFabricator())
+    register(InstantFabricator())
+    register(LocalDateFabricator())
+    register(LocalTimeFabricator())
+    register(LocalDateTimeFabricator())
+    register(YearMonthFabricator())
+    register(OffsetDateTimeFabricator())
+    register(OffsetTimeFabricator())
+    register(ZonedDateTimeFabricator())
+    register(DurationFabricator())
+    register(DateFabricator())
+    register(UriFabricator())
+    register(UrlFabricator())
+    register(FileFabricator())
+    register(UUIDFabricator())
+    register(AnyFabricator())
 }

--- a/fabrikate4k/src/main/kotlin/dev/forkhandles/fabrikate/Fabrikate.kt
+++ b/fabrikate4k/src/main/kotlin/dev/forkhandles/fabrikate/Fabrikate.kt
@@ -1,6 +1,47 @@
 package dev.forkhandles.fabrikate
 
-class Fabrikate(val config: FabricatorConfig = FabricatorConfig().withStandardMappings()) {
-    inline fun <reified T : Any> random(): T =
-        InstanceFabricator(config).makeRandomInstance(T::class, getKType<T>()) as T
+import kotlin.reflect.KClass
+
+class Fabrikate(
+    val config: FabricatorConfig = FabricatorConfig().withStandardMappings(),
+) {
+    companion object {
+        fun withMappings(fn: MutableMap<KClass<*>, Fabricator<*>>.() -> Unit): Fabrikate =
+            Fabrikate(FabricatorConfig().withMappings(fn))
+
+        fun withStandardMappings(): Fabrikate =
+            withMappings { registerStandardMappings() }
+    }
+
+    inline fun <reified T : Any> random(config: FabricatorConfig = this.config): T {
+        val fabrikate = if (config == this.config) this else Fabrikate(config)
+        return InstanceFabricator(fabrikate).makeRandomInstance(T::class, getKType<T>()) as T
+    }
+
+    inline fun <reified T : Any> random(noinline configFn: (FabricatorConfig) -> FabricatorConfig): T =
+        withConfig(configFn).random()
+
+    inline fun <reified T : Any> random(fabricator: Fabricator<T>): T = fabricator(this)
+
+    inline operator fun <reified T : Any> invoke(
+        fabricator: Fabricator<T>,
+        configFn: (FabricatorConfig) -> FabricatorConfig = { it },
+    ): T = random(configFn(config).withMapping(fabricator))
+
+    fun withConfig(configFn: (FabricatorConfig) -> FabricatorConfig): Fabrikate =
+        Fabrikate(configFn(config))
+
+    inline fun <reified T : Any> withMapping(fn: Fabricator<T>): Fabrikate =
+        Fabrikate(config.withMapping(fn))
+
+    fun withMappings(fn: MutableMap<KClass<*>, Fabricator<*>>.() -> Unit): Fabrikate =
+        Fabrikate(config.withMappings(fn))
 }
+
+inline operator fun <reified T : Any> Fabricator<T>.invoke(configFn: (FabricatorConfig) -> FabricatorConfig = { it }): T =
+    invoke(Fabrikate(), configFn)
+
+inline operator fun <reified T : Any> Fabricator<T>.invoke(
+    fabrikate: Fabrikate,
+    configFn: (FabricatorConfig) -> FabricatorConfig = { it },
+): T = fabrikate(this, configFn)

--- a/fabrikate4k/src/test/kotlin/dev/forkhandles/fabrikate/InstanceFabricatorTest.kt
+++ b/fabrikate4k/src/test/kotlin/dev/forkhandles/fabrikate/InstanceFabricatorTest.kt
@@ -407,7 +407,7 @@ class InstanceFabricatorTest {
     }
 
     class TestListFabricator: Fabricator<List<String>>{
-        override fun invoke(): List<String> {
+        override fun invoke(fabrikate: Fabrikate): List<String> {
             return testList
         }
 


### PR DESCRIPTION
Hello,

I tried to improve the API of the module, by extracting `random` from the fabricators to use the current `Fabrikate` instead. With an access to `fabrikate` inside a fabricator, we can create some answer complex cases. For example, when dealing with recursivity in the model : 
```kotlin
interface Person {
    val name: String
}

data class Parent(
    override val name: String,
    val children: List<Person>,
) : Person

data class Child(
    override val name: String,
) : Person

val myRandomParent: Fabricator<Parent> = Fabricator {
    Parent(it.random(), it.random<List<Child>>())
}

val myRandomPerson: Fabricator<Person> = Fabricator {
    if (!it.config.random.nextBoolean()) it.random<Parent>()
    else it.random<Child>()
}

val config = FabricatorConfig()
    .register(StringFabricator())
    .register(myRandomParent)
    .register(myRandomPerson)

val randomPerson: Person = Fabrikate(config).random()

/*
Parent(
    name=DAel,
    children=[
        Child(name=P56I7)
    ]
)
*/
```

The changes in the API also allows us to quickly create fabricators and override the behavior when needed (see README.md).

I also added parameters to some fabricators (Int, Long, Double) and introduced Year and Month fabricators.

NB: these are breaking changes, but I tried to keep them as small as possible