### PR TITLE
[result4k-hamkrest] Added extra matchers

### DIFF
--- a/result4k/hamkrest/src/main/kotlin/dev/forkhandles/result4k/hamkrest/matchers.kt
+++ b/result4k/hamkrest/src/main/kotlin/dev/forkhandles/result4k/hamkrest/matchers.kt
@@ -2,31 +2,33 @@ package dev.forkhandles.result4k.hamkrest
 
 import com.natpryce.hamkrest.MatchResult
 import com.natpryce.hamkrest.Matcher
-import com.natpryce.hamkrest.describe
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.has
 import dev.forkhandles.result4k.Failure
 import dev.forkhandles.result4k.Result4k
 import dev.forkhandles.result4k.Success
-import kotlin.reflect.KClass
 
-fun <T> isSuccess(expected: T): Matcher<Result4k<T, *>> = matchValue(Success(expected))
-fun isSuccess(): Matcher<Result4k<*, *>> = matchType(Success::class)
+fun <T> isSuccess(expected: T): Matcher<Result4k<T, *>> = isSuccess(equalTo(expected))
+fun <T> isSuccess(matcher: Matcher<T>): Matcher<Result4k<T, *>> =
+    isA<Success<T>>(has("value", Success<T>::value, matcher))
+fun <T> isSuccess(): Matcher<Result4k<T, *>> = isA<Success<T>>()
+fun <E> isFailure(expected: E): Matcher<Result4k<*, E>> = isFailure(equalTo(expected))
+fun <E> isFailure(matcher: Matcher<E>): Matcher<Result4k<*, E>> =
+    isA<Failure<E>>(has("reason", Failure<E>::reason, matcher))
 
-fun <E> isFailure(expected: E): Matcher<Result4k<*, E>> = matchValue(Failure(expected))
-fun isFailure(): Matcher<Result4k<*, *>> = matchType(Failure::class)
+fun <E> isFailure(): Matcher<Result4k<*, E>> = isA<Failure<E>>()
 
-private fun matchValue(expected: Result4k<*, *>) = object : Matcher<Result4k<*, *>> {
-    override fun invoke(actual: Result4k<*, *>) = match(actual == expected) { "was: ${describe(actual)}" }
-    override val description: String get() = "is ${describe(expected)}"
-    override val negatedDescription: String get() = "is not ${describe(expected)}"
-}
+// same as hamkrest's isA, but only prints the simple name of the class instead of the fully qualified name
+private inline fun <reified T : Result4k<*, *>> isA(downcastMatcher: Matcher<T>? = null) = object : Matcher<Any> {
+    override fun invoke(actual: Any) =
+        if (actual !is T) {
+            MatchResult.Mismatch("was: $actual")
+        } else if (downcastMatcher == null) {
+            MatchResult.Match
+        } else {
+            downcastMatcher(actual)
+        }
 
-private fun <T : Result4k<*, *>> matchType(expected: KClass<T>) = object : Matcher<Result4k<*, *>> {
-    override fun invoke(actual: Result4k<*, *>) = match(expected.isInstance(actual)) { "was: ${describe(actual)}" }
-    override val description: String get() = "is ${expected.simpleName}"
-    override val negatedDescription: String get() = "is not ${expected.simpleName}"
-}
-
-private inline fun match(comparison: Boolean, describeMismatch: () -> String): MatchResult = when {
-    comparison -> MatchResult.Match
-    else -> MatchResult.Mismatch(describeMismatch())
+    override val description: String
+        get() = "is a ${T::class.simpleName}" + if (downcastMatcher == null) "" else " and ${downcastMatcher.description}"
 }

--- a/result4k/hamkrest/src/test/kotlin/dev/forkhandles/result4k/hamkrest/MatchersTest.kt
+++ b/result4k/hamkrest/src/test/kotlin/dev/forkhandles/result4k/hamkrest/MatchersTest.kt
@@ -34,11 +34,11 @@ class MatchersTest {
         val actualValue = "Test successful"
         val actualResult = Success(actualValue)
 
-        throwsAssertionError("expected: a value that is Failure\nbut was: Success(value=Test successful)") {
+        throwsAssertionError("expected: a value that is a Failure\nbut was: Success(value=Test successful)") {
             assertThat(actualResult, isFailure())
         }
 
-        throwsAssertionError("expected: a value that is Failure(reason=Test successful)\nbut was: Success(value=Test successful)") {
+        throwsAssertionError("expected: a value that is a Failure and has reason that is equal to \"Test successful\"\nbut was: Success(value=Test successful)") {
             assertThat(actualResult, isFailure(actualValue))
         }
     }
@@ -48,12 +48,32 @@ class MatchersTest {
         val actualValue = "Test failed"
         val actualResult = Failure(actualValue)
 
-        throwsAssertionError("expected: a value that is Success\nbut was: Failure(reason=Test failed)") {
+        throwsAssertionError("expected: a value that is a Success\nbut was: Failure(reason=Test failed)") {
             assertThat(actualResult, isSuccess())
         }
 
-        throwsAssertionError("expected: a value that is Success(value=Test failed)\nbut was: Failure(reason=Test failed)") {
+        throwsAssertionError("expected: a value that is a Success and has value that is equal to \"Test failed\"\nbut was: Failure(reason=Test failed)") {
             assertThat(actualResult, isSuccess(actualValue))
+        }
+    }
+
+    @Test
+    fun `should correctly assert when Success and expecting Success with inner matcher`() {
+        val actualValue = "Test success"
+        val actualResult = Success(actualValue)
+
+        throwsAssertionError("expected: a value that is a Success and has value that is equal to \"Test Success\"\nbut had value that was: \"Test success\"") {
+            assertThat(actualResult, isSuccess(equalTo("Test Success")))
+        }
+    }
+
+    @Test
+    fun `should correctly assert when Failure and expecting Failure with inner matcher`() {
+        val actualValue = "Test failure"
+        val actualResult = Failure(actualValue)
+
+        throwsAssertionError("expected: a value that is a Failure and has reason that is equal to \"Test Failure\"\nbut had reason that was: \"Test failure\"") {
+            assertThat(actualResult, isFailure(equalTo("Test Failure")))
         }
     }
 

--- a/result4k/hamkrest/src/test/kotlin/dev/forkhandles/result4k/hamkrest/WeatherExampleHamkrest.kt
+++ b/result4k/hamkrest/src/test/kotlin/dev/forkhandles/result4k/hamkrest/WeatherExampleHamkrest.kt
@@ -1,6 +1,11 @@
 package dev.forkhandles.result4k.hamkrest
 
+import com.natpryce.hamkrest.and
 import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.greaterThan
+import com.natpryce.hamkrest.has
+import com.natpryce.hamkrest.isA
+import com.natpryce.hamkrest.lessThan
 import dev.forkhandles.result4k.Weather
 import dev.forkhandles.result4k.WeatherError
 import dev.forkhandles.result4k.getWeather
@@ -18,11 +23,23 @@ class WeatherExampleHamkrest {
     )
 
     @Test
+    fun `assert ranged success failure`() = assertThat(
+        getWeather(9001),
+        isSuccess(has(Weather::pascals, greaterThan(100_000) and lessThan(200_000)))
+    )
+
+    @Test
     fun `assert any failure`() = assertThat(getWeather(9001), isFailure())
 
     @Test
     fun `assert exact failure`() = assertThat(
         getWeather(9001),
         isFailure(WeatherError(404, "unsupported location"))
+    )
+
+    @Test
+    fun `assert ranged failure`() = assertThat(
+        getWeather(9001),
+        isFailure(isA<WeatherError>(has(WeatherError::code, greaterThan(400) and lessThan(500))))
     )
 }

--- a/result4k/hamkrest/src/test/kotlin/dev/forkhandles/result4k/hamkrest/WeatherExampleHamkrest.kt
+++ b/result4k/hamkrest/src/test/kotlin/dev/forkhandles/result4k/hamkrest/WeatherExampleHamkrest.kt
@@ -23,7 +23,7 @@ class WeatherExampleHamkrest {
     )
 
     @Test
-    fun `assert ranged success failure`() = assertThat(
+    fun `assert ranged success`() = assertThat(
         getWeather(20),
         isSuccess(has(Weather::pascals, greaterThan(100_000) and lessThan(200_000)))
     )

--- a/result4k/hamkrest/src/test/kotlin/dev/forkhandles/result4k/hamkrest/WeatherExampleHamkrest.kt
+++ b/result4k/hamkrest/src/test/kotlin/dev/forkhandles/result4k/hamkrest/WeatherExampleHamkrest.kt
@@ -4,7 +4,6 @@ import com.natpryce.hamkrest.and
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.greaterThan
 import com.natpryce.hamkrest.has
-import com.natpryce.hamkrest.isA
 import com.natpryce.hamkrest.lessThan
 import dev.forkhandles.result4k.Weather
 import dev.forkhandles.result4k.WeatherError
@@ -40,6 +39,6 @@ class WeatherExampleHamkrest {
     @Test
     fun `assert ranged failure`() = assertThat(
         getWeather(9001),
-        isFailure(isA<WeatherError>(has(WeatherError::code, greaterThan(400) and lessThan(500))))
+        isFailure(has(WeatherError::code, greaterThan(400) and lessThan(500)))
     )
 }

--- a/result4k/hamkrest/src/test/kotlin/dev/forkhandles/result4k/hamkrest/WeatherExampleHamkrest.kt
+++ b/result4k/hamkrest/src/test/kotlin/dev/forkhandles/result4k/hamkrest/WeatherExampleHamkrest.kt
@@ -24,7 +24,7 @@ class WeatherExampleHamkrest {
 
     @Test
     fun `assert ranged success failure`() = assertThat(
-        getWeather(9001),
+        getWeather(20),
         isSuccess(has(Weather::pascals, greaterThan(100_000) and lessThan(200_000)))
     )
 


### PR DESCRIPTION
Added an overload for `isFailure` and `isSuccess` that runs a matcher on the inner `value` or `reason`. These are useful as it allows for assertions that are not equality based to used on the inner data. See [WeatherExampleHamkrest](https://github.com/fork-handles/forkhandles/pull/45/files#diff-ed89c6b775a52c239dde65539bd81472366e43fec5ec415fda2709d1a0d0f48e) for an example.

This resulted in slightly changed error messages (see tests), but the assertions themselves are backwards compatible. There is a potential backward incompatibility if someone was using the `isSuccess` to test equality of `Result<Matcher, *>`. I would be shocked to discover this was actually occurring.

I considered using a default argument of `anything` instead of an no-arg overload but the error messages were much worse. I also rewrote the old code to use more of the builtin matchers included in hamkrest, and made one custom one to improve error messages when doing type assertions on Results.

Added tests for the inner matchers as well.