### PR TITLE
[result4k] added `resultFromCatching` for catching a specific type of exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This list is not intended to be all-encompassing - it will document major and breaking API changes with their rationale
 when appropriate:
 
+### v2.15.0.0
+- **result4k** : Add `resultFromCatching` to catch some (but not all!) exceptions and turn them into a `Result4k` H/T @MarcusDunn
+
 ### v2.14.0.0
 - **all** : Upgrade of dependencies, including Kotlin to 1.9.23
 - **data4k** : Add ability to declare child data-type fields (eg. JsonNode or submap) with data() and optionalData()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This list is not intended to be all-encompassing - it will document major and breaking API changes with their rationale
 when appropriate:
 
-### v2.15.0.0
+### v2.14.1.0
 - **result4k** : Add `resultFromCatching` to catch some (but not all!) exceptions and turn them into a `Result4k` H/T @MarcusDunn
 
 ### v2.14.0.0

--- a/result4k/core/src/main/kotlin/dev/forkhandles/result4k/result.kt
+++ b/result4k/core/src/main/kotlin/dev/forkhandles/result4k/result.kt
@@ -21,6 +21,16 @@ inline fun <T> resultFrom(block: () -> T): Result<T, Exception> =
     }
 
 /**
+ * Call a block and catch a specific Throwable type, returning it as an `Err` value.
+ */
+inline fun <reified E : Throwable, T> resultFromCatching(block: () -> T): Result<T, E> = resultFrom(block).mapFailure {
+    when (it) {
+        is E -> it
+        else -> throw it
+    }
+}
+
+/**
  * Map a function over the `value` of a successful `Result`.
  */
 inline fun <T, Tʹ, E> Result<T, E>.map(f: (T) -> Tʹ): Result<Tʹ, E> =

--- a/result4k/core/src/test/kotlin/dev/forkhandles/result4k/catching_tests.kt
+++ b/result4k/core/src/test/kotlin/dev/forkhandles/result4k/catching_tests.kt
@@ -1,0 +1,37 @@
+package dev.forkhandles.result4k
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class CatchingTests {
+    @Test
+    fun `check catch specific error`() {
+        val result = resultFromCatching<IllegalArgumentException, _> {
+            throw IllegalArgumentException("error")
+        }
+        val failure = result as? Failure
+        assertEquals("error", failure?.reason?.message)
+    }
+
+    @Test
+    fun `check do not specific error`() {
+        val exception = assertThrows<IllegalArgumentException> {
+            resultFromCatching<IllegalStateException, _> {
+                throw IllegalArgumentException("error")
+            }
+            fail("should not reach here")
+        }
+        assertEquals("error", exception.message)
+    }
+
+    @Test
+    fun `check success`() {
+        val result = resultFromCatching<IllegalArgumentException, _> {
+            "success"
+        }
+        val success = result as? Success
+        assertEquals("success", success?.value)
+    }
+}


### PR DESCRIPTION
`resultFrom` is a nice way to bridge exception throwing code with more controlled results, but catching every exception type is often not what one wants or you may know the exception type that will be thrown. `resultFromCatching` allow catching a subset of `Exeption` types.

I've had this extension function in my own code base for a bit now - It gets used fairly often (and is preferred over `resultFrom`) and I thought it may be wanted in the library itself.

# Example
```kt
fun DateTimeFormatter.parseResult(dateString: String) = resultFromCatching<DateTimeParseException, _> { parse(dateString) }
```