### PR TITLE
[result4k] Prevent unintuitively behaving bounds on `resultFromCatching` from compiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This list is not intended to be all-encompassing - it will document major and breaking API changes with their rationale
 when appropriate:
 
+### v2.16.0.0
+- **result4k** : [Breaking change] Changed bounds in `resultFromCatching` from `Throwable` to `Exception`. 
+
 ### v2.15.1.0
 - **data4k** : Rename methods for consistency. Old methods have been deprecated.
 

--- a/result4k/core/src/main/kotlin/dev/forkhandles/result4k/result.kt
+++ b/result4k/core/src/main/kotlin/dev/forkhandles/result4k/result.kt
@@ -23,7 +23,7 @@ inline fun <T> resultFrom(block: () -> T): Result<T, Exception> =
 /**
  * Call a block and catch a specific Throwable type, returning it as an `Err` value.
  */
-inline fun <reified E : Throwable, T> resultFromCatching(block: () -> T): Result<T, E> = resultFrom(block).mapFailure {
+inline fun <reified E : Exception, T> resultFromCatching(block: () -> T): Result<T, E> = resultFrom(block).mapFailure {
     when (it) {
         is E -> it
         else -> throw it


### PR DESCRIPTION
This prevents the following code from compiling

```kotlin
resultFromCatching<NotImplementedError, _> {
    throw NotImplementedError("catch me if you can")
}
```

Unintuitively, this would throw instead of resulting in a `Failure<NotImplementedError>` as `resultFrom` would not catch it (it only catches `Exception`s)

This would be a breaking change but catching `Error`s is generally a bad idea anyways. 

