### PR TITLE
Update Maven badge link for Result4K

### DIFF
--- a/result4k/README.md
+++ b/result4k/README.md
@@ -1,6 +1,6 @@
 # Result4K
 
-<a href="https://mvnrepository.com/artifact/dev.forkhandles"><img alt="Download" src="https://img.shields.io/maven-central/v/dev.forkhandles/forkhandles-bom"></a>
+<a href="https://central.sonatype.com/artifact/dev.forkhandles/result4k"><img alt="Download" src="https://img.shields.io/maven-central/v/dev.forkhandles/forkhandles-bom"></a>
 [![.github/workflows/build.yaml](https://github.com/fork-handles/forkhandles/actions/workflows/build.yaml/badge.svg)](https://github.com/fork-handles/forkhandles/actions/workflows/build.yaml)
 
 <a href="http//www.apache.org/licenses/LICENSE-2.0"><img alt="GitHub license" src="https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat"></a>


### PR DESCRIPTION
It should be indicated to MavenCentral instead of the others.