### PR TITLE
Fix variable name in comment of Result#recover function

### DIFF
--- a/result4k/core/src/main/kotlin/dev/forkhandles/result4k/result.kt
+++ b/result4k/core/src/main/kotlin/dev/forkhandles/result4k/result.kt
@@ -111,7 +111,7 @@ inline fun <T, E> Result<T, E>.onFailure(block: (Failure<E>) -> Nothing): T = wh
 }
 
 /**
- * Unwrap a `Result` by returning the success value or calling `failureToValue` to mapping the failure reason to a plain value.
+ * Unwrap a `Result` by returning the success value or calling `errorToValue` to mapping the failure reason to a plain value.
  */
 inline fun <S, T : S, U : S, E> Result<T, E>.recover(errorToValue: (E) -> U): S =
     mapFailure(errorToValue).get()


### PR DESCRIPTION
The even better solution would probably be to rename the function argument from `errorToValue` to `failureToValue` because the whole Result4k type does not use the term `error`, however I was not sure if that may be a breaking change that we do not want to introduce so it's a start to at least fix the reference in the comment.