### PR TITLE
Add ability to iterate over text lines in Fs4k TextFile

### DIFF
--- a/fs4k/src/main/kotlin/dev/forkhandles/fs4k/Fs4kFile.kt
+++ b/fs4k/src/main/kotlin/dev/forkhandles/fs4k/Fs4kFile.kt
@@ -11,6 +11,7 @@ interface Fs4kFile : Fs4kEntity {
      * Represents a text file in the filesystem.
      */
     interface Text : Fs4kFile {
+        var lines: List<String>
         var content: String
 
         companion object

--- a/fs4k/src/main/kotlin/dev/forkhandles/fs4k/disk/TextFile.kt
+++ b/fs4k/src/main/kotlin/dev/forkhandles/fs4k/disk/TextFile.kt
@@ -27,6 +27,13 @@ internal class TextFile(private val file: File, private val createMode: CreateMo
 
     override fun delete() = file.delete()
 
+    override var lines: List<String>
+        get() = file.reader().readLines()
+        set(value) {
+            toWrite = value.joinToString("\n")
+            if (createMode == CreateMode.Automatic) create()
+        }
+
     override var content: String
         get() = file.reader().readText()
         set(value) {

--- a/fs4k/src/test/kotlin/dev/forkhandles/fs4k/Fs4kDirContract.kt
+++ b/fs4k/src/test/kotlin/dev/forkhandles/fs4k/Fs4kDirContract.kt
@@ -16,8 +16,11 @@ interface Fs4kDirContract {
     @Test
     fun `creates files automatically`() {
         val dir = dir(nonExistingPath, Automatic, fs4k) {
-            text("plainfile.txt") {
+            text("plainfile_content.txt") {
                 content = "hello"
+            }
+            text("plainfile_lines.txt") {
+                lines = listOf("hello")
             }
             binary("binary.png") {
                 content = "goodbye".byteInputStream()
@@ -30,8 +33,11 @@ interface Fs4kDirContract {
             }
         }
 
-        assertTrue(dir.exists(nonExistingPath, "plainfile.txt"), "plainfile.txt should exist")
-        assertEquals("hello", dir.content(nonExistingPath, "plainfile.txt"))
+        assertTrue(dir.exists(nonExistingPath, "plainfile_content.txt"), "plainfile_content.txt should exist")
+        assertEquals("hello", dir.content(nonExistingPath, "plainfile_content.txt"))
+
+        assertTrue(dir.exists(nonExistingPath, "plainfile_lines.txt"), "plainfile_lines.txt should exist")
+        assertEquals("hello", dir.content(nonExistingPath, "plainfile_lines.txt"))
 
         assertTrue(dir.exists(nonExistingPath, "binary.png"), "binary.png should exist")
         assertEquals("goodbye", dir.content(nonExistingPath, "binary.png"))


### PR DESCRIPTION
Sometimes you just need to be able to iterate over lines in a file, and not just read full text at once.