### PR TITLE
Enable return-value-checker=full for Result4k (Kotlin 2.2.20)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.2.0"
+kotlin = "2.2.20"
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.9.0"
 kotlinx-benchmark = "0.4.14"

--- a/result4k/core/build.gradle
+++ b/result4k/core/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 }
 
 compileJmhKotlin.kotlinOptions.jvmTarget = "11"
+kotlin.compilerOptions.freeCompilerArgs.add("-Xreturn-value-checker=full")
 
 test {
     include("dev/forkhandles/**")

--- a/result4k/core/build.gradle
+++ b/result4k/core/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testApi(libs.kotlin.test)
 }
 
-compileJmhKotlin.kotlinOptions.jvmTarget = "1.8"
+compileJmhKotlin.kotlinOptions.jvmTarget = "11"
 
 test {
     include("dev/forkhandles/**")

--- a/result4k/core/src/main/kotlin/dev/forkhandles/result4k/reject_retain.kt
+++ b/result4k/core/src/main/kotlin/dev/forkhandles/result4k/reject_retain.kt
@@ -1,12 +1,10 @@
 package dev.forkhandles.result4k
 
-
 inline fun <T, E> Result<T, E>.retainIf(test: (T) -> Boolean, otherwise: () -> E): Result<T, E> =
     flatMap { if (test(it)) Success(it) else Failure(otherwise()) }
 
 inline fun <T, E> Result<T, E>.rejectIf(test: (T) -> Boolean, error: () -> E): Result<T, E> =
     retainIf({ !test(it) }, error)
-
 
 inline fun <T, E> Result<T, E>.retainIf(b: Boolean, otherwise: () -> E): Result<T, E> =
     flatMap { if (b) Success(it) else Failure(otherwise()) }

--- a/result4k/core/src/main/kotlin/dev/forkhandles/result4k/result.kt
+++ b/result4k/core/src/main/kotlin/dev/forkhandles/result4k/result.kt
@@ -10,8 +10,8 @@ sealed class Result<out T, out E>
 data class Success<out T>(val value: T) : Result<T, Nothing>()
 data class Failure<out E>(val reason: E) : Result<Nothing, E>()
 
-fun <T> T.asSuccess(): Result<T,Nothing> = Success(this)
-fun <E> E.asFailure(): Result<Nothing,E> = Failure(this)
+fun <T> T.asSuccess(): Result<T, Nothing> = Success(this)
+fun <E> E.asFailure(): Result<Nothing, E> = Failure(this)
 
 val begin = Unit.asSuccess()
 
@@ -110,11 +110,10 @@ fun <T, X : Throwable> Result<T, X>.orThrow(): T = when (this) {
 /**
  * Unwrap a successful result or convert an error into an exception and throw it
  */
-fun <T, E> Result<T, E>.orThrow(x: (E)->Throwable): T = when (this) {
+fun <T, E> Result<T, E>.orThrow(x: (E) -> Throwable): T = when (this) {
     is Success<T> -> value
     is Failure<E> -> throw x(reason)
 }
-
 
 /**
  * Unwrap a `Result`, by returning the success value or calling `block` on failure to abort from the current function.

--- a/result4k/core/src/test/kotlin/dev/forkhandles/result4k/WeatherExample.kt
+++ b/result4k/core/src/test/kotlin/dev/forkhandles/result4k/WeatherExample.kt
@@ -33,6 +33,6 @@ fun main() {
         .map { it.message } // convert success to message
         .peekFailure { println("Physics has imploded!") }  // perform side-effect if failure
         .recover { message -> "WARNING: $message" } // convert failure to message
-    
+
     println(forecast)
 }

--- a/result4k/core/src/test/kotlin/dev/forkhandles/result4k/catching_tests.kt
+++ b/result4k/core/src/test/kotlin/dev/forkhandles/result4k/catching_tests.kt
@@ -18,7 +18,7 @@ class CatchingTests {
     @Test
     fun `check do not specific error`() {
         val exception = assertThrows<IllegalArgumentException> {
-            resultFromCatching<IllegalStateException, _> {
+            val _ = resultFromCatching<IllegalStateException, _> {
                 throw IllegalArgumentException("error")
             }
             fail("should not reach here")

--- a/result4k/core/src/test/kotlin/dev/forkhandles/result4k/on_null_tests.kt
+++ b/result4k/core/src/test/kotlin/dev/forkhandles/result4k/on_null_tests.kt
@@ -15,7 +15,7 @@ class OnNullTests {
 
     @Test
     fun `does nothing on unsuccessful result`() {
-        fun subject() = resultFrom { throw AnError("kaboom"); "unreachable" }
+        fun subject() = resultFrom<String> { throw AnError("kaboom") }
             .onNull { return Success("early-returned") }
 
         assertEquals(Failure(AnError("kaboom")), subject())

--- a/result4k/core/src/test/kotlin/dev/forkhandles/result4k/orthrow_tests.kt
+++ b/result4k/core/src/test/kotlin/dev/forkhandles/result4k/orthrow_tests.kt
@@ -20,14 +20,14 @@ class OrThrowTests {
 
         assertThrows<ExampleException> { r.orThrow() }
     }
-    
+
     @Test
     fun `convenience function to convert failure to exception and throw`() {
-        val r : Result<Int,String> = Failure("error value")
+        val r: Result<Int, String> = Failure("error value")
         val e = assertThrows<ExampleException> {
             r.orThrow { ExampleException(it) }
         }
-        
+
         assertEquals("error value", e.message)
     }
 }

--- a/result4k/core/src/test/kotlin/dev/forkhandles/result4k/orthrow_tests.kt
+++ b/result4k/core/src/test/kotlin/dev/forkhandles/result4k/orthrow_tests.kt
@@ -18,14 +18,14 @@ class OrThrowTests {
     fun `failure is thrown if an exception`() {
         val r: Result<String, ExampleException> = Failure(ExampleException())
 
-        assertThrows<ExampleException> { r.orThrow() }
+        assertThrows<ExampleException> { val _ = r.orThrow() }
     }
 
     @Test
     fun `convenience function to convert failure to exception and throw`() {
         val r: Result<Int, String> = Failure("error value")
         val e = assertThrows<ExampleException> {
-            r.orThrow { ExampleException(it) }
+            val _ = r.orThrow { ExampleException(it) }
         }
 
         assertEquals("error value", e.message)

--- a/result4k/core/src/test/kotlin/dev/forkhandles/result4k/reject_retain_tests.kt
+++ b/result4k/core/src/test/kotlin/dev/forkhandles/result4k/reject_retain_tests.kt
@@ -6,31 +6,31 @@ import kotlin.test.assertEquals
 class RejectRetainTests {
     sealed class Error
     data class TooBig(val limit: Int) : Error()
-    
+
     @Test
     fun `retaining values`() {
         val a = 10
-        
+
         assertEquals(
             Success(a),
             a.asSuccess().retainIf({ it <= 15 }, otherwise = { TooBig(limit = 15) })
         )
-        
+
         assertEquals(
             a.asSuccess().retainIf({ it <= 15 }, { TooBig(limit = 15) }),
             a.asSuccess().rejectIf({ it > 15 }, { TooBig(limit = 15) })
         )
     }
-    
+
     @Test
     fun `rejecting values`() {
         val a = 20
-        
+
         assertEquals(
             Failure(TooBig(15)),
             a.asSuccess().retainIf({ it <= 15 }, otherwise = { TooBig(limit = 15) })
         )
-        
+
         assertEquals(
             a.asSuccess().retainIf({ it <= 15 }, { TooBig(limit = 15) }),
             a.asSuccess().rejectIf({ it > 15 }, { TooBig(limit = 15) })


### PR DESCRIPTION
Annoyingly this will report "Conflicting overloads" in IDE for main() in petStoreExample.kt and WeatherExample.kt.
This is already fixed though and will be available in the next Kotlin release I guess https://youtrack.jetbrains.com/issue/KT-79085/Adding-Xreturn-value-checkerfull-to-kotlinc-causes-error-conflicting-overloads