### PR TITLE
evaluated value access for failure branch, and dedicated nullability handling

### DIFF
--- a/result4k/core/src/main/kotlin/dev/forkhandles/result4k/reject_retain.kt
+++ b/result4k/core/src/main/kotlin/dev/forkhandles/result4k/reject_retain.kt
@@ -11,3 +11,9 @@ inline fun <T, E> Result<T, E>.retainIf(b: Boolean, otherwise: () -> E): Result<
 
 inline fun <T, E> Result<T, E>.rejectIf(b: Boolean, error: () -> E): Result<T, E> =
     retainIf(!b, error)
+
+inline fun <T, E> Result<T, E>.retainIfNotNull(otherwise: (T) -> E): Result<T, E> =
+    flatMap { it?.asSuccess() ?: Failure(otherwise(it)) }
+
+inline fun <T, E> Result<T, E>.rejectIfNull(otherwise: (T) -> E): Result<T, E> =
+    flatMap { it?.asSuccess() ?: Failure(otherwise(it)) }

--- a/result4k/core/src/main/kotlin/dev/forkhandles/result4k/reject_retain.kt
+++ b/result4k/core/src/main/kotlin/dev/forkhandles/result4k/reject_retain.kt
@@ -1,9 +1,9 @@
 package dev.forkhandles.result4k
 
-inline fun <T, E> Result<T, E>.retainIf(test: (T) -> Boolean, otherwise: () -> E): Result<T, E> =
-    flatMap { if (test(it)) Success(it) else Failure(otherwise()) }
+inline fun <T, E> Result<T, E>.retainIf(test: (T) -> Boolean, otherwise: (T) -> E): Result<T, E> =
+    flatMap { if (test(it)) Success(it) else Failure(otherwise(it)) }
 
-inline fun <T, E> Result<T, E>.rejectIf(test: (T) -> Boolean, error: () -> E): Result<T, E> =
+inline fun <T, E> Result<T, E>.rejectIf(test: (T) -> Boolean, error: (T) -> E): Result<T, E> =
     retainIf({ !test(it) }, error)
 
 inline fun <T, E> Result<T, E>.retainIf(b: Boolean, otherwise: () -> E): Result<T, E> =

--- a/result4k/core/src/test/kotlin/dev/forkhandles/result4k/reject_retain_tests.kt
+++ b/result4k/core/src/test/kotlin/dev/forkhandles/result4k/reject_retain_tests.kt
@@ -26,6 +26,11 @@ class RejectRetainTests {
             a.asSuccess().retainIf({ it <= 15 }, { TooBigWithActual(limit = 15, actual = it) }),
             a.asSuccess().rejectIf({ it > 15 }, { TooBigWithActual(limit = 15, actual = it) })
         )
+
+        assertEquals(
+            a.asSuccess().retainIfNotNull({ TooBig(limit = 15) }),
+            a.asSuccess().rejectIfNull({ TooBig(limit = 15) })
+        )
     }
 
     @Test

--- a/result4k/core/src/test/kotlin/dev/forkhandles/result4k/reject_retain_tests.kt
+++ b/result4k/core/src/test/kotlin/dev/forkhandles/result4k/reject_retain_tests.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertEquals
 class RejectRetainTests {
     sealed class Error
     data class TooBig(val limit: Int) : Error()
+    data class TooBigWithActual(val limit: Int, val actual: Int) : Error()
 
     @Test
     fun `retaining values`() {
@@ -19,6 +20,11 @@ class RejectRetainTests {
         assertEquals(
             a.asSuccess().retainIf({ it <= 15 }, { TooBig(limit = 15) }),
             a.asSuccess().rejectIf({ it > 15 }, { TooBig(limit = 15) })
+        )
+
+        assertEquals(
+            a.asSuccess().retainIf({ it <= 15 }, { TooBigWithActual(limit = 15, actual = it) }),
+            a.asSuccess().rejectIf({ it > 15 }, { TooBigWithActual(limit = 15, actual = it) })
         )
     }
 
@@ -34,6 +40,11 @@ class RejectRetainTests {
         assertEquals(
             a.asSuccess().retainIf({ it <= 15 }, { TooBig(limit = 15) }),
             a.asSuccess().rejectIf({ it > 15 }, { TooBig(limit = 15) })
+        )
+
+        assertEquals(
+            a.asSuccess().retainIf({ it <= 15 }, { TooBigWithActual(limit = 15, actual = it) }),
+            a.asSuccess().rejectIf({ it > 15 }, { TooBigWithActual(limit = 15, actual = it) })
         )
     }
 }


### PR DESCRIPTION
`rejectIf` and `retainIf` has access to evaluated value, so it is easier to chain function calls

and additional `retainIfNotNull` and `rejectIfNull` that explicitly handle nullability - agin for easier chaining of functions 