### PR TITLE
Unused result checking

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,9 +52,10 @@ subprojects {
         withType<KotlinJvmCompile>().configureEach {
             compilerOptions {
                 jvmTarget.set(JVM_11)
+                freeCompilerArgs.add("-Xreturn-value-checker=full")
             }
         }
-
+        
         java {
             sourceCompatibility = VERSION_11
             targetCompatibility = VERSION_11

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,7 +112,6 @@ subprojects {
     }
 
     dependencies {
-        api(rootProject.libs.kotlin.stdlib)
         testApi(platform(rootProject.libs.junit.bom))
         testApi(rootProject.libs.junit.jupiter)
         testApi(rootProject.libs.junit.jupiter.api)

--- a/bunting4k/src/test/kotlin/dev/forkhandles/bunting/BuntingTest.kt
+++ b/bunting4k/src/test/kotlin/dev/forkhandles/bunting/BuntingTest.kt
@@ -12,17 +12,20 @@ class BuntingTest {
     private val testIo = TestIO()
     private val testConfig = InMemoryConfig()
 
+    @Suppress("EnumEntryName")
     enum class AnEnum {
         a, b
     }
 
     class MyGrandChildFlags(args: Array<String>, io: IO) : Bunting(args, io = io, baseCommand = "MyTestFlags")
 
+    @Suppress("unused")
     class MyChildFlags(args: Array<String>, io: IO) : Bunting(args, "This is a command flag", "MyTestFlags", io) {
         val noDescription by option().defaultsTo("no description default")
         val grandchild by command { MyGrandChildFlags(it, io) }
     }
 
+    @Suppress("unused")
     class MyTestFlags(args: Array<String>, io: IO, config: Config) : Bunting(args, "some description of all my commands", "MyTestFlags", io = io, config = config) {
         val switch: Boolean by switch("This is a switch")
         val optional: String by option("This is an optional flag").required()
@@ -50,9 +53,9 @@ class BuntingTest {
         class Foo(args: Array<String>, io: IO) : Bunting(args, "description", "foo", io = io) {
             val aReallyReallyReallyReallyReallyReallyReallyReallyLongName by option("some description").defaultsTo("foobar")
         }
-
+        
         Foo(arrayOf("--help"), testIo).use {
-            aReallyReallyReallyReallyReallyReallyReallyReallyLongName
+            val _ = aReallyReallyReallyReallyReallyReallyReallyReallyLongName
         }
         assertThat(testIo.toString(), equalTo("""Usage: foo [commands] [options]
 description
@@ -143,7 +146,7 @@ description
     @Test
     fun `illegal prompted secret flag does not leak value`() {
         MyTestFlags(arrayOf("-s", "foobar"), testIo, testConfig).use {
-            secret
+            val _ = secret
         }
         assertThat(testIo.toString(), equalTo("Usage: MyTestFlags [commands] [options]\n" +
             "Illegal --secret (INT) flag: ******. Use --help for docs."))
@@ -160,7 +163,7 @@ description
     @Test
     fun `missing required flag rejected`() {
         MyTestFlags(arrayOf(), testIo, testConfig).use {
-            required
+            val _ = required
         }
         assertThat(testIo.toString(), equalTo("""Usage: MyTestFlags [commands] [options]
 Missing --required (STRING) flag. Use --help for docs."""))
@@ -229,7 +232,7 @@ Missing --required (STRING) flag. Use --help for docs."""))
     @Test
     fun `illegal value flag`() {
         MyTestFlags(arrayOf("--mapped", "asd"), testIo, testConfig).use {
-            mapped
+            val _ = mapped
         }
         assertThat(testIo.toString(), equalTo("Usage: MyTestFlags [commands] [options]\n" +
             "Illegal --mapped (INT) flag: asd. Use --help for docs."))
@@ -282,7 +285,7 @@ Missing --required (STRING) flag. Use --help for docs."""))
 
         Foo(arrayOf("command"), testIo).use {
             command.use {
-                required
+                val _ = required
             }
         }
 
@@ -342,7 +345,7 @@ Missing --required (STRING) flag. Use --help for docs."""))
         }
 
         ExtensionFlags(arrayOf("--boolean", "foobar"), testIo).use {
-            boolean
+            val _ = boolean
         }
         assertThat(testIo.toString(), equalTo("""Usage: foo [commands] [options]
 Illegal --boolean (BOOLEAN) flag: foobar. Use --help for docs."""))

--- a/fabrikate4k/src/test/kotlin/dev/forkhandles/fabrikate/InstanceFabricatorTest.kt
+++ b/fabrikate4k/src/test/kotlin/dev/forkhandles/fabrikate/InstanceFabricatorTest.kt
@@ -191,9 +191,8 @@ class InstanceFabricatorTest {
         assertTrue(gaa2.t1 is Long)
         assertTrue(gaa2.t2 is List<Int>)
 
-        val gta: GTA<Long, String> = Fabrikate().random()
-        gta.t2.length
-
+        val _: GTA<Long, String> = Fabrikate().random()
+        
         val gaaga: GAA<Long, GA<GT<Int>>> = Fabrikate().random()
         assertTrue(gaaga.t1 is Long)
         assertTrue(gaaga.t2 is GA<GT<Int>>)

--- a/fabrikate4k/src/test/kotlin/dev/forkhandles/fabrikate/InstanceFabricatorTest.kt
+++ b/fabrikate4k/src/test/kotlin/dev/forkhandles/fabrikate/InstanceFabricatorTest.kt
@@ -71,7 +71,7 @@ class InstanceFabricatorTest {
     @Test
     fun `throws NoUsableConstructor error if there is no constructor that could be used`() {
         try {
-            Fabrikate().random<P>()
+            val _ = Fabrikate().random<P>()
             error("makeRandomInstance should throw NoUsableConstructor error")
         } catch (e: NoUsableConstructor) {
             // no-op

--- a/fs4k/src/main/kotlin/dev/forkhandles/fs4k/Fs4kDir.kt
+++ b/fs4k/src/main/kotlin/dev/forkhandles/fs4k/Fs4kDir.kt
@@ -13,17 +13,19 @@ interface Fs4kDir: Fs4kEntity {
     /**
      * Create a binary file in the directory.
      */
+    @IgnorableReturnValue
     fun binary(name: String, fn: Fs4kFile.Binary.() -> Unit = {}): Fs4kFile.Binary
 
     /**
      * Create a text file in the directory.
      */
+    @IgnorableReturnValue
     fun text(name: String, fn: Fs4kFile.Text.() -> Unit = {}): Fs4kFile.Text
 
     /**
      * Create a subdirectory in the directory.
      */
+    @IgnorableReturnValue
     fun dir(name: String, fn: Fs4kDir.() -> Unit = {}): Fs4kDir
-
 }
 

--- a/fs4k/src/main/kotlin/dev/forkhandles/fs4k/Fs4kEntity.kt
+++ b/fs4k/src/main/kotlin/dev/forkhandles/fs4k/Fs4kEntity.kt
@@ -1,7 +1,11 @@
 package dev.forkhandles.fs4k
 
 interface Fs4kEntity {
+    @IgnorableReturnValue
     fun create(): Boolean
+    
+    @IgnorableReturnValue
     fun delete(): Boolean
+    
     fun exists(): Boolean
 }

--- a/mock4k/src/test/kotlin/dev/forkhandles/mock4k/MockTest.kt
+++ b/mock4k/src/test/kotlin/dev/forkhandles/mock4k/MockTest.kt
@@ -64,7 +64,7 @@ class MockTest {
     @Test
     fun `function mock supported`() {
         try {
-            AppleStore(mock()).buyMacbookUsing(mock())
+            val _ = AppleStore(mock()).buyMacbookUsing(mock())
             fail("didn't throw")
         } catch (e: UnstubbedCall) {
             assertThat(e.message, equalTo("Unstubbed call: Function2.invoke(MacBook, 9999)"))
@@ -74,7 +74,7 @@ class MockTest {
     @Test
     fun `fails on unexpected call`() {
         try {
-            AppleStore(mock<Wallet>()).buyMacBook()
+            val _ = AppleStore(mock<Wallet>()).buyMacBook()
             fail("didn't throw")
         } catch (e: UnstubbedCall) {
             assertThat(e.message, equalTo("Unstubbed call: Wallet.pay(MacBook, 9999)"))
@@ -86,7 +86,7 @@ class MockTest {
 
         runBlocking {
             try {
-                AppleStore(mock<Wallet>()).buyMacbookLater()
+                val _ = AppleStore(mock<Wallet>()).buyMacbookLater()
                 fail("didn't throw")
             } catch (e: UnstubbedCall) {
                 assertThat(e.message, equalTo("Unstubbed call: Wallet.pay(MacBook, 9999)"))

--- a/parser4k/src/test/kotlin/parser4k/examples/json/json-parser.kt
+++ b/parser4k/src/test/kotlin/parser4k/examples/json/json-parser.kt
@@ -202,7 +202,7 @@ class JsonParserTests {
 
         testCases.forEach { file ->
             try {
-                parse(file.readText())
+                val _ = parse(file.readText())
                 if (file.name.startsWith("fail")) fail("Expected failure: ${file.name}")
             } catch (e: Exception) {
                 if (file.name.startsWith("pass")) throw e

--- a/parser4k/src/test/kotlin/parser4k/one-of-tests.kt
+++ b/parser4k/src/test/kotlin/parser4k/one-of-tests.kt
@@ -32,7 +32,7 @@ class OneOfTests {
         val log = ParsingLog { logEvents.add(it) }
         val parser = oneOf(str("abc").with("abc", log))
 
-        parser.parse(Input("abc", offset = 3))
+        val _ = parser.parse(Input("abc", offset = 3))
 
         logEvents shouldEqual emptyList<ParsingEvent>()
     }

--- a/parser4k/src/test/kotlin/parser4k/output-cache-tests.kt
+++ b/parser4k/src/test/kotlin/parser4k/output-cache-tests.kt
@@ -61,7 +61,7 @@ class `Cached parsers are called at most one time at each offset` {
 
     @Test
     fun `log when parsing '123'`() {
-        "123".parseWith(plusMinusGrammar.expr)
+        val _ = "123".parseWith(plusMinusGrammar.expr)
         logEvents.toDebugString() shouldEqual """
             "123" plus:0
             "123" plus:0 minus:0

--- a/parser4k/src/test/kotlin/parser4k/test-util.kt
+++ b/parser4k/src/test/kotlin/parser4k/test-util.kt
@@ -3,9 +3,11 @@ package parser4k
 import org.junit.jupiter.api.Assertions.assertEquals
 
 
+@IgnorableReturnValue
 infix fun Any?.shouldEqual(expected: Any?) =
     assertEquals(expected, this)
 
+@IgnorableReturnValue
 infix fun (() -> Any?).shouldFailWith(f: (ParsingError) -> Boolean) =
     try {
         this()
@@ -13,6 +15,7 @@ infix fun (() -> Any?).shouldFailWith(f: (ParsingError) -> Boolean) =
         assert(f(e))
     }
 
+@IgnorableReturnValue
 infix fun (() -> Any?).shouldFailWithMessage(expectedMessage: String) =
     try {
         this()

--- a/result4k/core/build.gradle
+++ b/result4k/core/build.gradle
@@ -8,9 +8,6 @@ dependencies {
     testApi(libs.kotlin.test)
 }
 
-compileJmhKotlin.kotlinOptions.jvmTarget = "11"
-kotlin.compilerOptions.freeCompilerArgs.add("-Xreturn-value-checker=full")
-
 test {
     include("dev/forkhandles/**")
     scanForTestClasses true

--- a/result4k/core/build.gradle
+++ b/result4k/core/build.gradle
@@ -18,13 +18,6 @@ test {
         junitXml.required = true
         html.required = true
     }
-
-    beforeTest { desc ->
-        print "${desc.className.substring("dev.forkhandles.".length())}: ${desc.name.replace("_", " ")}"
-    }
-    afterTest { desc, result ->
-        println " -> ${result.resultType}"
-    }
 }
 
 artifacts {

--- a/result4k/hamkrest/src/test/kotlin/dev/forkhandles/result4k/hamkrest/MatchersTest.kt
+++ b/result4k/hamkrest/src/test/kotlin/dev/forkhandles/result4k/hamkrest/MatchersTest.kt
@@ -77,6 +77,7 @@ class MatchersTest {
         }
     }
 
+    @IgnorableReturnValue
     private fun throwsAssertionError(message: String, block: () -> Unit) =
         assertThrows<AssertionError> { block() }.also {
             assertThat(it.message, present(equalTo(message)))

--- a/result4k/kotest/src/main/kotlin/dev/forkhandles/result4k/kotest/matchers.kt
+++ b/result4k/kotest/src/main/kotlin/dev/forkhandles/result4k/kotest/matchers.kt
@@ -22,6 +22,7 @@ fun beSuccess(): Matcher<Result<*, *>> = object : Matcher<Result<*, *>> {
 }
 
 @OptIn(ExperimentalContracts::class)
+@IgnorableReturnValue
 fun <T> Result<T, *>.shouldBeSuccess(): T {
     contract {
         returns() implies (this@shouldBeSuccess is Success<T>)
@@ -45,6 +46,7 @@ fun beFailure(): Matcher<Result<*, *>> = object : Matcher<Result<*, *>> {
 }
 
 @OptIn(ExperimentalContracts::class)
+@IgnorableReturnValue
 fun <E> Result<*, E>.shouldBeFailure(): E {
     contract {
         returns() implies (this@shouldBeFailure is Failure<*>)
@@ -54,8 +56,7 @@ fun <E> Result<*, E>.shouldBeFailure(): E {
 }
 
 infix fun <E> Result<*, E>.shouldBeFailure(block: (E) -> Unit) {
-    this.shouldBeFailure()
-    block((this as Failure<E>).reason)
+    block(this.shouldBeFailure())
 }
 
 infix fun <E> Result<*, E>.shouldBeFailure(expected: E) =

--- a/result4k/kotest/src/test/kotlin/dev/forkhandles/result4k/kotest/MatchersTest.kt
+++ b/result4k/kotest/src/test/kotlin/dev/forkhandles/result4k/kotest/MatchersTest.kt
@@ -84,6 +84,7 @@ class MatchersTest {
         Success("Actual value") shouldBeSuccess "Expected value"
     }
 
+    @IgnorableReturnValue
     private fun throwsAssertionError(message: String, block: () -> Unit) =
         assertThrows<AssertionError> { block() }.also {
             assertThat(it.message, present(equalTo(message)))

--- a/result4k/strikt/src/main/kotlin/dev/forkhandles/result4k/strikt/matchers.kt
+++ b/result4k/strikt/src/main/kotlin/dev/forkhandles/result4k/strikt/matchers.kt
@@ -6,25 +6,31 @@ import strikt.api.Assertion
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 
+@IgnorableReturnValue
 fun Assertion.Builder<*>.isSuccess() =
     isA<Success<*>>()
 
+@IgnorableReturnValue
 fun Assertion.Builder<*>.isFailure() =
     isA<Failure<*>>()
 
 @JvmName("isSuccessOfInstance")
+@IgnorableReturnValue
 inline fun <reified T> Assertion.Builder<*>.isSuccess() =
     isA<Success<T>>().and { get { value }.isA<T>() }
 
 @JvmName("isFailureOfInstance")
+@IgnorableReturnValue
 inline fun <reified E> Assertion.Builder<*>.isFailure() =
     isA<Failure<E>>().and { get { reason }.isA<E>() }
 
 @JvmName("isSuccessOfInstanceAndValue")
+@IgnorableReturnValue
 inline fun <reified T> Assertion.Builder<*>.isSuccess(expected: T) =
     isA<Success<T>>().and { get { value }.isEqualTo(expected) }
 
 @JvmName("isFailureOfInstanceAndValue")
+@IgnorableReturnValue
 inline fun <reified E> Assertion.Builder<*>.isFailure(expected: E) =
     isA<Failure<E>>().and { get { reason }.isEqualTo(expected) }
 

--- a/result4k/strikt/src/test/kotlin/dev/forkhandles/result4k/strikt/MatchersTest.kt
+++ b/result4k/strikt/src/test/kotlin/dev/forkhandles/result4k/strikt/MatchersTest.kt
@@ -70,6 +70,7 @@ class MatchersTest {
         }
     }
 
+    @IgnorableReturnValue
     private fun expectAssertionError(message: String, block: () -> Unit) =
         expectThrows<AssertionError> { block() }
             .and { get { subject.formatterMessage }.isEqualTo(message) }

--- a/ropes4k/src/test/kotlin/dev/forkhandles/ropes4k/test/RopeContract.kt
+++ b/ropes4k/src/test/kotlin/dev/forkhandles/ropes4k/test/RopeContract.kt
@@ -29,8 +29,6 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
-import java.nio.file.Files
-import java.nio.file.Path
 
 abstract class RopeContract {
 
@@ -73,10 +71,11 @@ abstract class RopeContract {
     fun testLengthOverflow() {
         val r = (2..30).fold(make("01")) { acc, i -> acc.append(acc) }
         expectThat(r.length).isEqualTo(1073741824)
+        
         try {
-            r.append(r)
+            val _ = r.append(r)
             Assertions.fail<Any>("Expected overflow.")
-        } catch (e: IllegalArgumentException) {
+        } catch (_: IllegalArgumentException) {
             // this is what we expect
         }
     }
@@ -425,7 +424,7 @@ abstract class RopeContract {
 
 
     @Test
-    fun `adding`() {
+    fun adding() {
         val r1 = make("11")
         val r2 = make("22")
         expectThat(r1 + r2).isEqualTo(r1.append(r2))
@@ -433,6 +432,7 @@ abstract class RopeContract {
     }
 
 
+    @IgnorableReturnValue
     fun <T : Rope> strikt.api.Assertion.Builder<T>.startsWith(
         expected: CharSequence,
         startIndex: Int
@@ -446,6 +446,7 @@ abstract class RopeContract {
         }
 
 
+    @IgnorableReturnValue
     fun <T : Rope> strikt.api.Assertion.Builder<T>.endsWith(
         expected: CharSequence,
         startIndex: Int

--- a/ropes4k/src/test/kotlin/dev/forkhandles/ropes4k/test/RopeTest.kt
+++ b/ropes4k/src/test/kotlin/dev/forkhandles/ropes4k/test/RopeTest.kt
@@ -32,6 +32,7 @@ class RopeTest {
         return out.toString()
     }
 
+    @IgnorableReturnValue
     private fun <T : Iterator<Char>> Assertion.Builder<T>.isFinished(): Assertion.Builder<Boolean> {
         return get { hasNext() }.isEqualTo(false)
     }
@@ -82,7 +83,7 @@ class RopeTest {
         for (j in 2..30) x1 = x1.append(x1)
         expectThat(x1.length).isEqualTo(1073741824)
         try {
-            x1.append(x1)
+            val _ = x1.append(x1)
             Assertions.fail<Any>("Expected overflow.")
         } catch (e: IllegalArgumentException) {
             // this is what we expect
@@ -121,7 +122,7 @@ class RopeTest {
         var i: Iterator<Char> = c2.iterator()
         for (j in 0 until c2.length) {
             Assertions.assertTrue(i.hasNext(), "Has next (" + j + "/" + c2.length + ")")
-            i.next()
+            val _ = i.next()
         }
         expectThat(i).isFinished()
 
@@ -138,7 +139,7 @@ class RopeTest {
         expectThat(i).isFinished()
         for (j in 0..z3.length) {
             try {
-                z3.iterator(j)
+                val _ = z3.iterator(j)
             } catch (e: Exception) {
                 Assertions.fail<Any>("$j $e")
             }
@@ -146,7 +147,7 @@ class RopeTest {
         Assertions.assertTrue(4 == z4.length)
         for (j in 0..z4.length) {
             try {
-                z4.iterator(j)
+                val _ = z4.iterator(j)
             } catch (e: Exception) {
                 Assertions.fail<Any>("$j $e")
             }
@@ -198,12 +199,12 @@ class RopeTest {
     @Test
     fun testCreation() {
         try {
-            Rope.of("The quick brown fox jumped over")
+            val _ = Rope.of("The quick brown fox jumped over")
         } catch (e: Exception) {
             Assertions.fail<Any>("Nonempty string: " + e.message)
         }
         try {
-            Rope.of("")
+            val _ = Rope.of("")
         } catch (e: Exception) {
             Assertions.fail<Any>("Empty string: " + e.message)
         }
@@ -453,7 +454,7 @@ class RopeTest {
             Rope.ofCopy("01234567890123456789012345678901234567890123456789012345678901234567890123456789".toCharArray())
         val r2 = r.subSequence(0, 30)
         try {
-            r2[31]
+            val _ = r2[31]
             Assertions.fail<Any>("Expected IndexOutOfBoundsException")
         } catch (e: IndexOutOfBoundsException) {
             // success
@@ -592,21 +593,21 @@ class RopeTest {
 
         expectThrows<NoSuchElementException> {
             rs.iterator().also {
-                it.next()
-                it.next()
+                val _ = it.next()
+                val _ = it.next()
             }
         }
         expectThrows<NoSuchElementException> {
             rca.iterator().also {
-                it.next()
-                it.next()
+                val _ = it.next()
+                val _ = it.next()
             }
         }
         expectThrows<NoSuchElementException> {
             cat.iterator().also {
-                it.next()
-                it.next()
-                it.next()
+                val _ = it.next()
+                val _ = it.next()
+                val _ = it.next()
             }
         }
     }

--- a/ropes4k/src/test/kotlin/dev/forkhandles/ropes4k/test/extensions.kt
+++ b/ropes4k/src/test/kotlin/dev/forkhandles/ropes4k/test/extensions.kt
@@ -13,6 +13,7 @@ import strikt.api.Assertion
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 
+@IgnorableReturnValue
 fun <T : Rope> Assertion.Builder<T>.isString(s: String): Assertion.Builder<String> {
     return get { this.toString() }.isEqualTo(s)
 }

--- a/time4k/src/main/kotlin/dev/forkhandles/time/TestTimeSources.kt
+++ b/time4k/src/main/kotlin/dev/forkhandles/time/TestTimeSources.kt
@@ -13,6 +13,7 @@ interface TickableTimeSource : TimeSource {
     /**
      * Advance the underlying time by a custom amount, or the default amount if no value is passed.
      */
+    @IgnorableReturnValue
     fun tick(amount: Duration? = null): TickableTimeSource
 }
 
@@ -47,5 +48,7 @@ class FixedTimeSource(
 class AutoTickingTimeSource(private val underlying: TickableTimeSource) : TickableTimeSource by underlying {
     constructor(time: Instant = EPOCH, tick: Duration = ofSeconds(1)) : this(FixedTimeSource(time, tick))
 
-    override operator fun invoke() = underlying().also { underlying.tick() }
+    override operator fun invoke() = underlying().also {
+        underlying.tick()
+    }
 }

--- a/time4k/src/main/kotlin/dev/forkhandles/time/executors/SimpleSchedulerService.kt
+++ b/time4k/src/main/kotlin/dev/forkhandles/time/executors/SimpleSchedulerService.kt
@@ -35,7 +35,8 @@ class SimpleSchedulerService(private val executor: ScheduledExecutorService) : S
 
     override fun isShutdown(): Boolean = executor.isShutdown
 
+    @IgnorableReturnValue
     override fun submit(task: Runnable): Future<*> = executor.submit(task)
-
+    
     override fun <T> submit(task: Callable<T>): Future<T> = executor.submit(task)
 }

--- a/tx4k/build.gradle.kts
+++ b/tx4k/build.gradle.kts
@@ -9,10 +9,3 @@ dependencies {
     testImplementation(libs.bundles.testcontainers.postgres)
     testImplementation(libs.bundles.testcontainers.mariadb)
 }
-
-
-tasks.withType<KotlinJvmCompile>().configureEach {
-    compilerOptions {
-        freeCompilerArgs.set(freeCompilerArgs.get() + "-Xinline-classes")
-    }
-}

--- a/tx4k/src/test/kotlin/dev/forkhandles/tx/TransactorContract.kt
+++ b/tx4k/src/test/kotlin/dev/forkhandles/tx/TransactorContract.kt
@@ -60,7 +60,7 @@ abstract class TransactorContract {
                         }
                     }
                 } catch (_: SerialisabilityFailure) {
-                    failureCount.incrementAndFetch()
+                    val _ = failureCount.incrementAndFetch()
                 } catch (_: ForceARollback) {
                     // Expected, but catch here to prevent the executor writing a lot of noise to stderr
                 }

--- a/values4k/build.gradle.kts
+++ b/values4k/build.gradle.kts
@@ -8,10 +8,3 @@ dependencies {
 
     testImplementation("com.ubertob.kondor:kondor-tools:3.6.1")
 }
-
-
-tasks.withType<KotlinJvmCompile>().configureEach {
-    compilerOptions {
-        freeCompilerArgs.set(freeCompilerArgs.get() + "-Xinline-classes")
-    }
-}

--- a/values4k/src/test/kotlin/dev/forkhandles/values/ValueFactoryTest.kt
+++ b/values4k/src/test/kotlin/dev/forkhandles/values/ValueFactoryTest.kt
@@ -13,17 +13,17 @@ class ValueFactoryTest {
     @Test
     fun `throwable factory`() {
         assertThat(MyIntValue.of(123), equalTo(MyIntValue.of(123)))
-        assertThat({ MyIntValue.of(0) }, throws<IllegalArgumentException>())
+        assertThat({ val _ = MyIntValue.of(0) }, throws<IllegalArgumentException>())
 
         assertThat(MyIntValue.ofList(), equalTo(listOf()))
         assertThat(MyIntValue.ofList(123, 456), equalTo(listOf(MyIntValue.of(123), MyIntValue.of(456))))
-        assertThat({ MyIntValue.ofList(0, 1) }, throws<IllegalArgumentException>())
+        assertThat({ val _ = MyIntValue.ofList(0, 1) }, throws<IllegalArgumentException>())
     }
 
     @Test
     fun `throwable factory as function`() {
         assertThat(MyIntValue.of(123), equalTo(MyIntValue.of(123)))
-        assertThat({ MyIntValue.of(0) }, throws<IllegalArgumentException>())
+        assertThat({ val _ = MyIntValue.of(0) }, throws<IllegalArgumentException>())
     }
 
     @Test
@@ -65,11 +65,11 @@ class ValueFactoryTest {
     @Test
     fun `throwable parse`() {
         assertThat(MyIntValue.parse("123"), equalTo(MyIntValue.of(123)))
-        assertThat({ MyIntValue.parse("") }, throws<IllegalArgumentException>())
+        assertThat({ val _ = MyIntValue.parse("") }, throws<IllegalArgumentException>())
 
         assertThat(MyIntValue.parseList(), equalTo(listOf()))
         assertThat(MyIntValue.parseList("123", "456"), equalTo(listOf(MyIntValue.of(123), MyIntValue.of(456))))
-        assertThat({ MyIntValue.parseList("") }, throws<IllegalArgumentException>())
+        assertThat({ val _ = MyIntValue.parseList("") }, throws<IllegalArgumentException>())
     }
 
     @Test


### PR DESCRIPTION
Turn on full unused result checking for all modules
Address unused result warnings by annotating methods or explicitly ignoring results
Remove obsolete or unnecessary build rules

